### PR TITLE
Minimum combined AdePT/Celeritas/None offload interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,50 +6,85 @@ include(CTest)
 include(FetchContent)
 
 # -- Externals
+# Here we now have an issue of possible duplication, so we
+# 1. Setup Celeritas first,
+# 2. then G4VG so it uses local Celeritas::geocel,
+# 3. then AdePT so it uses local G4VG
+# If/when G4VG becomes standalone, this will continue to work depending
+# on how AdePT/Celeritas pick it up
+
+# We have to set this so that packages found/required by Celeritas
+# are visible when linking Celeritas to g4vg/AdePT
+set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
+
 # Set up default options here (TBD if we want users to set these)
 # Or.. in CMake setting files
 set(CELERITAS_USE_CUDA ON)
 set(CELERITAS_USE_Geant4 ON)
+set(CELERITAS_USE_VecGeom ON)
 set(CELERITAS_USE_MPI OFF)
 set(CELERITAS_USE_SWIG OFF)
+set(CELERITAS_USE_Python OFF)
+set(CELERITAS_USE_ROOT OFF)
+# These are required for correct interworking...
+set(CELERITAS_CORE_GEO VecGeom)
+set(CELERITAS_UNITS CLHEP)
+set(CELERITAS_REAL_TYPE double)
 
-FetchContent_Declare(
-  adept
-  GIT_REPOSITORY https://github.com/apt-sim/adept.git
-  GIT_TAG        8e7b9b49f1730f8db6ff3520942fd5ae64760b21 # master, so will need to bring in code from MR 268!
-)
 FetchContent_Declare(
   celeritas
   GIT_REPOSITORY https://github.com/celeritas-project/celeritas.git
-  GIT_TAG        c0f4129c391a6d7cfad41f3e0e3ccd0445633732 # v0.4.1
+  GIT_TAG        90c62fe91545d1ed92b29256ddce1a2af3132ada # develop
 )
-FetchContent_MakeAvailable(adept celeritas)
+FetchContent_MakeAvailable(celeritas)
+
+# Force Celeritas "found" so g4vg will use Celeritas::geocel from local FetchContent
+set(Celeritas_FOUND ON)
+FetchContent_Declare(
+  g4vg
+  GIT_REPOSITORY https://github.com/celeritas-project/g4vg.git
+  GIT_TAG        9fd87968a8248e0050e831fffdd89e0346b96147 # main
+)
+FetchContent_MakeAvailable(g4vg)
+
+# As above, force G4VG "found" so AdePT will use G4VG from local FetchContent
+# TODO: work out why this fails with "No known features for CUDA compiler" for
+# the flush try-compile on first run, but succeeds on second.
+set(G4VG_FOUND ON)
+FetchContent_Declare(
+  adept
+  GIT_REPOSITORY https://github.com/drbenmorgan/adept.git
+  GIT_TAG        c30469b0f074f9015d809817363c6a44c665d890 # update-g4vg
+)
+FetchContent_MakeAvailable(adept)
 
 # Post fetchcontent setup
 list(APPEND CMAKE_MODULE_PATH ${celeritas_SOURCE_DIR}/cmake)
 find_package(Geant4 REQUIRED)
 
 # -- Build the offloader library
-include(CeleritasLibrary)
-celeritas_add_library(GPUOffload
+include(CudaRdcUtils)
+cuda_rdc_add_library(GPUOffload
   GPUOffload/GPUOffload.cc
   GPUOffload/adept/AdeptOffload.cc
   GPUOffload/celeritas/CeleritasOffload.cc
-  GPUOffload/celeritas/Celeritas.cc)
-celeritas_target_include_directories(GPUOffload
+  GPUOffload/celeritas/Celeritas.cc
+  GPUOffload/none/NoOffload.cc)
+cuda_rdc_target_include_directories(GPUOffload
   PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/GPUOffload>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
-celeritas_target_link_libraries(GPUOffload
+cuda_rdc_target_link_libraries(GPUOffload
   Celeritas::accel
+  AdePT::AdePT_G4_integration
   ${Geant4_LIBRARIES}
 )
 
 # Minimal exe. Use celeritas linking to resolve RDC linking if shared libs are used
 add_executable(trackingmanager-offload trackingmanager-offload.cc)
-celeritas_target_link_libraries(trackingmanager-offload
-  Celeritas::accel
+cuda_rdc_target_link_libraries(trackingmanager-offload
   GPUOffload
   ${Geant4_LIBRARIES}
 )
+add_test(NAME trackingmanager-offload COMMAND trackingmanager-offload)

--- a/GPUOffload/GPUOffload.cc
+++ b/GPUOffload/GPUOffload.cc
@@ -3,9 +3,16 @@
 #include "celeritas/CeleritasOffload.hh"
 
 #include "G4Threading.hh"
+#include "adept/AdeptOffload.hh"
+#include "none/NoOffload.hh"
 
 GPUOffloadInterface& GPUOffload()
 {
-  static G4ThreadLocal CeleritasOffload co;
-  return co;
+    // TODO: How to make the choice configurable at runtime given
+    // thread locality, type, and that "GPUOffload()" is a global
+    // function called in several places (so can't just use argument)
+    static G4ThreadLocal CeleritasOffload co;
+    // static G4ThreadLocal AdeptOffload co;
+    // static G4ThreadLocal NoOffload co;
+    return co;
 }

--- a/GPUOffload/adept/AdeptOffload.cc
+++ b/GPUOffload/adept/AdeptOffload.cc
@@ -1,36 +1,53 @@
 #include "AdeptOffload.hh"
 
+#include <AdePT/core/AdePTConfiguration.hh>
+#include <AdePT/core/AdePTTransport.h>
+#include <AdePT/integration/AdePTGeant4Integration.hh>
+#include <AdePT/integration/AdePTTrackingManager.hh>
 
-// Look at AdePT's new Example22 for how to implement the functions.
-// Just mocked in for now.
-#include "G4VTrackingManager.hh"
+// Thread local transporter
+AdePTTransport<AdePTGeant4Integration>* GetTransporter()
+{
+    // TODO: If created on stack/as unique_ptr (so deleted by tls at exit) get
+    // segfaults..
+    static G4ThreadLocal auto* transporter
+        = new AdePTTransport<AdePTGeant4Integration>;
+    return transporter;
+}
+
+// Global config
+AdePTConfiguration& GetConfiguration()
+{
+    static AdePTConfiguration config;
+    return config;
+}
 
 // Return concrete tracking manager for this offloader
 std::unique_ptr<G4VTrackingManager> AdeptOffload::MakeTrackingManager()
 {
-  return std::unique_ptr<G4VTrackingManager>();
+    // Modelled after AdePT's AdePTPhysics::ConstructProcess(), but adapted
+    // as we don't store the transporter/config in the physics list.
+    auto man = std::make_unique<AdePTTrackingManager>();
+    man->SetAdePTTransport(GetTransporter());
+    man->SetAdePTConfiguration(&GetConfiguration());
+
+    return man;
 }
 
 //! Initialization of this class on a worker thread
-void AdeptOffload::Build()
-{};
+void AdeptOffload::Build() {}
 
 //! Initialization of this class on the master thread
-void AdeptOffload::BuildForMaster()
-{}
+void AdeptOffload::BuildForMaster() {}
 
 // Perform any operations need on Run start
-void AdeptOffload::BeginOfRunAction(G4Run const* /*run*/)
-{}
+void AdeptOffload::BeginOfRunAction(G4Run const* /*run*/) {}
 
 // Perform any operations needed on Event start
-void AdeptOffload::BeginOfEventAction(G4Event const* /*event*/)
-{}
+void AdeptOffload::BeginOfEventAction(G4Event const* /*event*/) {}
 
 // Perform any operations needed on Event end;
-void AdeptOffload::EndOfEventAction(G4Event const* /*event*/)
-{}
+void AdeptOffload::EndOfEventAction(G4Event const* /*event*/) {}
 
 // Perform and operations needed on Run end;
-void AdeptOffload::EndOfRunAction(G4Run const* /*run*/)
-{}
+void AdeptOffload::EndOfRunAction(G4Run const* /*run*/) {}

--- a/GPUOffload/celeritas/Celeritas.cc
+++ b/GPUOffload/celeritas/Celeritas.cc
@@ -1,69 +1,69 @@
 #include "Celeritas.hh"
 
+#include <memory>
 #include <G4Threading.hh>
 #include <accel/AlongStepFactory.hh>
-#include <celeritas/field/UniformFieldData.hh>
-#include <celeritas/io/ImportData.hh>
 #include <accel/LocalTransporter.hh>
 #include <accel/SetupOptions.hh>
 #include <accel/SharedParams.hh>
-
-#include <memory>
+#include <celeritas/field/UniformFieldData.hh>
+#include <celeritas/io/ImportData.hh>
 
 using namespace celeritas;
 
 // Global shared setup options
 SetupOptions& CelerSetupOptions()
 {
-  static SetupOptions options = [] {
-    // Construct setup options the first time CelerSetupOptions is invoked
-    SetupOptions so;
+    static SetupOptions options = [] {
+        // Construct setup options the first time CelerSetupOptions is invoked
+        SetupOptions so;
 
-    // Set along-step factory
-    so.make_along_step = celeritas::UniformAlongStepFactory();
-    // NOTE: these numbers are appropriate for CPU execution
-    so.max_num_tracks = 1024;
-    // This will eventually go
-    so.max_num_events = 100000;
-    so.initializer_capacity = 1024 * 128;
-    // Celeritas does not support EmStandard MSC physics above 100 MeV
-    so.ignore_processes = {"CoulombScat"};
+        // Set along-step factory
+        so.make_along_step = celeritas::UniformAlongStepFactory();
+        // NOTE: these numbers are appropriate for CPU execution
+        so.max_num_tracks = 1024;
+        // This will eventually go
+        so.max_num_events = 100000;
+        so.initializer_capacity = 1024 * 128;
+        // Celeritas does not support EmStandard MSC physics above 100 MeV
+        so.ignore_processes = {"CoulombScat"};
 
-    // Use Celeritas "hit processor" to call back to Geant4 SDs.
-    so.sd.enabled = true;
+        // Use Celeritas "hit processor" to call back to Geant4 SDs.
+        so.sd.enabled = true;
 
-    // Only call back for nonzero energy depositions: this is currently a
-    // global option for all detectors, so if any SDs extract data from tracks
-    // with no local energy deposition over the step, it must be set to false.
-    so.sd.ignore_zero_deposition = false;
+        // Only call back for nonzero energy depositions: this is currently a
+        // global option for all detectors, so if any SDs extract data from
+        // tracks with no local energy deposition over the step, it must be set
+        // to false.
+        so.sd.ignore_zero_deposition = false;
 
-    // Using the pre-step point, reconstruct the G4 touchable handle.
-    so.sd.locate_touchable = true;
+        // Using the pre-step point, reconstruct the G4 touchable handle.
+        so.sd.locate_touchable = true;
 
-    // Pre-step time is used
-    so.sd.pre.global_time = true;
-    return so;
-  }();
-  return options;
+        // Pre-step time is used
+        so.sd.pre.global_time = true;
+        return so;
+    }();
+    return options;
 }
 
 // Shared data and GPU setup
 SharedParams& CelerSharedParams()
 {
-  static SharedParams sp;
-  return sp;
+    static SharedParams sp;
+    return sp;
 }
 
 // Thread-local transporter
 LocalTransporter& CelerLocalTransporter()
 {
-  static G4ThreadLocal LocalTransporter lt;
-  return lt;
+    static G4ThreadLocal LocalTransporter lt;
+    return lt;
 }
 
 // Thread-local offload interface
 SimpleOffload& CelerSimpleOffload()
 {
-  static G4ThreadLocal SimpleOffload so;
-  return so;
+    static G4ThreadLocal SimpleOffload so;
+    return so;
 }

--- a/GPUOffload/celeritas/Celeritas.hh
+++ b/GPUOffload/celeritas/Celeritas.hh
@@ -8,7 +8,7 @@ namespace celeritas
 class LocalTransporter;
 struct SetupOptions;
 class SharedParams;
-}
+}  // namespace celeritas
 
 // Global shared setup options
 celeritas::SetupOptions& CelerSetupOptions();

--- a/GPUOffload/celeritas/CeleritasOffload.cc
+++ b/GPUOffload/celeritas/CeleritasOffload.cc
@@ -1,7 +1,7 @@
 #include "CeleritasOffload.hh"
 
-
 #include <accel/TrackingManagerOffload.hh>
+
 #include "Celeritas.hh"
 
 void CeleritasOffload::Build()

--- a/GPUOffload/none/NoOffload.cc
+++ b/GPUOffload/none/NoOffload.cc
@@ -1,0 +1,27 @@
+#include "NoOffload.hh"
+
+#include "G4VTrackingManager.hh"
+
+// Return concrete tracking manager for this offloader
+std::unique_ptr<G4VTrackingManager> NoOffload::MakeTrackingManager()
+{
+    return std::unique_ptr<G4VTrackingManager>(nullptr);
+}
+
+//! Initialization of this class on a worker thread
+void NoOffload::Build(){};
+
+//! Initialization of this class on the master thread
+void NoOffload::BuildForMaster() {}
+
+// Perform any operations need on Run start
+void NoOffload::BeginOfRunAction(G4Run const* /*run*/) {}
+
+// Perform any operations needed on Event start
+void NoOffload::BeginOfEventAction(G4Event const* /*event*/) {}
+
+// Perform any operations needed on Event end;
+void NoOffload::EndOfEventAction(G4Event const* /*event*/) {}
+
+// Perform and operations needed on Run end;
+void NoOffload::EndOfRunAction(G4Run const* /*run*/) {}

--- a/GPUOffload/none/NoOffload.hh
+++ b/GPUOffload/none/NoOffload.hh
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "GPUOffloadInterface.hh"
+
+class NoOffload final : public GPUOffloadInterface
+{
+  public:
+    // Return concrete tracking manager for this offloader
+    std::unique_ptr<G4VTrackingManager> MakeTrackingManager() override;
+
+    //! Initialization of this class on a worker thread
+    void Build() override;
+
+    //! Initialization of this class on the master thread
+    void BuildForMaster() override;
+
+    // Perform any operations need on Run start
+    void BeginOfRunAction(G4Run const* run) override;
+
+    // Perform any operations needed on Event start
+    void BeginOfEventAction(G4Event const* event) override;
+
+    // Perform any operations needed on Event end;
+    void EndOfEventAction(G4Event const* event) override;
+
+    // Perform and operations needed on Run end;
+    void EndOfRunAction(G4Run const* run) override;
+};

--- a/README.md
+++ b/README.md
@@ -8,15 +8,43 @@ concrete `G4VTrackingManager`s.
 - Future common testing problems (easy switching between impls)
 
 It's essentially (intended to be) a merge/blend of Celeritas' `accel` 
-examples and AdePT's `Example22`. At present only a trivial setup is
-used.
+examples and AdePT's `example1`. At present only a trivial setup is
+used to focus on the off/onload.
 
 # Build/Use
-The project uses CMake's `FetchContent` to pull in AdePT's `master`
-branch and Celeritas' v0.4.1 tag. The build should then work with
-either AdePT's LCG view or a Celeritas Spack view (if not, then relevant
-patches here or to the upstreams should be submitted).
+The project uses CMake's `FetchContent` to pull in the relevant branches
+of AdePT, Celeritas, and the supporting G4VG Geant4-VecGeom in memory converter.
+WIth these, the build should then work with either AdePT's LCG view or a 
+Celeritas Spack view (if not, then relevant patches here or to the upstreams
+should be submitted).
+
+**NB**: One current issue is that the _first_ invocation of CMake will result in
+an error:
+
+```console
+-- Performing Test Geant4_flush_FOUND
+CMake Error in /tmp/adept-build/ca-build/CMakeFiles/CMakeScratch/TryCompile-7OCbcN/CMakeLists.txt:
+  No known features for CUDA compiler
+
+  ""
+
+  version .
+
+
+CMake Error at /usr/share/cmake/Modules/Internal/CheckSourceCompiles.cmake:101 (try_compile):
+  Failed to generate test project build system.
+Call Stack (most recent call first):
+  /usr/share/cmake/Modules/CheckCXXSourceCompiles.cmake:76 (cmake_check_source_compiles)
+  /tmp/adept-build/ca-build/_deps/adept-src/CMakeLists.txt:105 (check_cxx_source_compiles)
+```
+
+**Just running `cmake` again will resolve the issue and yield a successful configuration,
+and then build.**
 
 The only program is the `trackingmanager-offload`, so just run this to
 test at the moment. Comments in `trackingmanager-offload.cc` should illustrate
 what's going on (and provide a basis for Doxygen going forward).
+
+This hardcodes the use of Celeritas offload, but this can be changed for
+the AdePT and no offload cases in `GPUOffload/GPUOffload.hh`.
+


### PR DESCRIPTION
- Update commit hashes to latest versions from upstream
- Configure Celeritas to cowork correctly with G4VG and Geant4
- Provide GPUOffloadInterface implementation for AdePT
- Provide GPUOffloadInterface implementation for "no offload" case to allow pure Geant4 running for comparison
- Update minimal example to score energy deposition for a minimal comparison test