### PR TITLE
Bump Celeritas dependency to fix Issue #4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CELERITAS_REAL_TYPE double)
 FetchContent_Declare(
   celeritas
   GIT_REPOSITORY https://github.com/celeritas-project/celeritas.git
-  GIT_TAG        90c62fe91545d1ed92b29256ddce1a2af3132ada # develop
+  GIT_TAG        17d96db867322102a7bb6f18a46ecda13871cd37 # develop
 )
 FetchContent_MakeAvailable(celeritas)
 


### PR DESCRIPTION
Incorrect energy deposition scoring result traced to Celeritas not reconstituting weights of G4StepPoint in addition to G4Track. Fixed in Celeritas PR:

- https://github.com/celeritas-project/celeritas/pull/1281

Bump Celeritas commit fetched to:

- https://github.com/celeritas-project/celeritas/commit/17d96db867322102a7bb6f18a46ecda13871cd37

to incorporate fix.

Fixes: #4 