### PR TITLE
Clarify why only one BeamOn is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ what's going on (and provide a basis for Doxygen going forward).
 This hardcodes the use of Celeritas offload, but this can be changed for
 the AdePT and no offload cases in `GPUOffload/GPUOffload.hh`.
 
+# Known Limitations
+## Only one Run is permitted after initialization
+As shown in [`trackingmanager-offload.cc`](./trackingmanager-offload.cc), only one
+call to `G4RunManager::BeamOn` can be made per application execution. This is due
+to the potential for geometry/physics to change between runs which would require
+reinitialization of GPU-side data for AdePT/Celeritas. Neither project supports
+this capability yet, as the primary HEP production use case does not require this.
+This may be added later, but for now only one run is supported.

--- a/trackingmanager-offload.cc
+++ b/trackingmanager-offload.cc
@@ -289,11 +289,10 @@ int main()
 
     run_manager->SetUserInitialization(new ActionInitialization());
     run_manager->Initialize();
-    // Do two runs to check behaviour between
+    // Only a single run is allowed because the offload implementations
+    // do not currently support updating geometry/physics that might change
+    // between runs (the "Idle" state)
     run_manager->BeamOn(10);
-    // This causes an exception in Celeritas "celeritas::activate_device may be
-    // called only once per application" AdePT is fine
-    //run_manager->BeamOn(16);
 
     return 0;
 }


### PR DESCRIPTION
Document why multiple `G4RunManager::BeamOn` calls are not done/supported, closing out Issue #6.