### PR TITLE
Provide interfaces to choose offload backend at runtime

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,9 +61,8 @@ ForEachMacros:
 IncludeBlocks:   Regroup
 # Category 0: main include
 # Category 1: system includes
-# Category 2: celeritas absolute includes
-# Category 5: relative includes
-# Category 7: test includes
+# Category 2: local relative includes
+# Category 3: test includes
 IncludeCategories:
   - Regex:           '^<[^/.]+>$'
     Priority:        1
@@ -71,40 +70,16 @@ IncludeCategories:
   - Regex:           '^<.+>$'
     Priority:        1
     SortPriority:    2
-  - Regex:           '^"celeritas_[a-z_]+\.h"'
+  - Regex:           '^"GPUOffload+\.hh"'
     Priority:        2
     SortPriority:    3
-  - Regex:           '^"corecel/device_runtime_api\.h"$'
+    CaseSensitive:   true
+  - Regex:           '^"(adept|celeritas|none)/'
     Priority:        2
     SortPriority:    3
-  - Regex:           '^"corecel/'
-    Priority:        2
-    SortPriority:    5
     CaseSensitive:   true
-  - Regex:           '^"orange/'
-    Priority:        2
-    SortPriority:    6
-    CaseSensitive:   true
-  - Regex:           '^"celeritas/'
-    Priority:        2
-    SortPriority:    7
-    CaseSensitive:   true
-  - Regex:           '^"accel/'
-    Priority:        2
-    SortPriority:    8
-    CaseSensitive:   true
-  - Regex:           '^"[^/]+"'
-    Priority:        5
-    SortPriority:    9
-  - Regex:           '^"detail/"'
-    Priority:        5
-    SortPriority:    10
-  - Regex:           '"(^gtest/|TestBase|\.test\.hh|celeritas_test\.hh)'
-    Priority:        7
-    CaseSensitive:   true
-    SortPriority:    11
   - Regex:           '.*'
-    Priority:        5
+    Priority:        3
     SortPriority:    9
 IncludeIsMainRegex: '(\.[^.]+)?$'
 IncludeIsMainSourceRegex: '(\.cu|\.t\.hh)$' # Allow CU/template files as main

--- a/GPUOffload/GPUOffload.cc
+++ b/GPUOffload/GPUOffload.cc
@@ -1,18 +1,101 @@
 #include "GPUOffload.hh"
 
+#include <memory>
+
 #include "celeritas/CeleritasOffload.hh"
 
+#include "G4Exception.hh"
 #include "G4Threading.hh"
 #include "adept/AdeptOffload.hh"
 #include "none/NoOffload.hh"
 
+namespace
+{
+// Global options for the offloader backend
+GPUOffloadOptions& global_offload_options()
+{
+    static GPUOffloadOptions opts;
+    return opts;
+}
+
+// Read only access to offloader backend options
+GPUOffloadOptions const& offload_options()
+{
+    return global_offload_options();
+}
+
+// Build a concrete offloader from options
+std::unique_ptr<GPUOffloadInterface>
+build_offloader(GPUOffloadOptions const& op)
+{
+    // Input options must be valid
+    if (!op)
+    {
+        G4Exception("GPUOffload.cc::build_offloader",
+                    "GPUOffload0003",
+                    FatalException,
+                    "attempted to build GPUOffloadInterface from invalid "
+                    "options");
+    }
+
+    switch (op.backend)
+    {
+        // Should GPUOffloadOptions need to be passed to the concrete
+        // offloader or builder function, the returns below can be from calls
+        // dedicated functions
+        case GPUOffloadBackend::Adept:
+            return std::make_unique<AdeptOffload>();
+        case GPUOffloadBackend::Celeritas:
+            return std::make_unique<CeleritasOffload>();
+        case GPUOffloadBackend::None:
+            return std::make_unique<NoOffload>();
+        default:
+            // shouldn't get here...
+            break;
+    }
+    // only logical return here, but we should never get here
+    return std::unique_ptr<GPUOffloadInterface>(nullptr);
+}
+
+// Return ref to thread-local offloader backend
+GPUOffloadInterface& local_offloader()
+{
+    static G4ThreadLocal auto op = build_offloader(offload_options());
+    // This assumes that op will hold be nullptr...
+    return *(op.get());
+}
+}  // namespace
+
+// Setup offloader backend backed. Can only be called once per process
+void GPUOffloadSetup(GPUOffloadOptions const& opts)
+{
+    static std::mutex m;
+    std::lock_guard<std::mutex> scoped_lock{m};
+    GPUOffloadOptions& go = global_offload_options();
+
+    if (go)
+    {
+        // Could also throw std::exception and let client handle...
+        G4Exception("GPUOffloadSetup",
+                    "GPUOffload0001",
+                    JustWarning,
+                    "GPUOffloadSetup already called");
+        return;
+    }
+
+    // Input options must be valid
+    if (!opts)
+    {
+        G4Exception("GPUOffloadSetup",
+                    "GPUOffload0002",
+                    FatalException,
+                    "invalid GPUOffloadOptions instance passed");
+    }
+
+    go = opts;
+}
+
 GPUOffloadInterface& GPUOffload()
 {
-    // TODO: How to make the choice configurable at runtime given
-    // thread locality, type, and that "GPUOffload()" is a global
-    // function called in several places (so can't just use argument)
-    static G4ThreadLocal CeleritasOffload co;
-    // static G4ThreadLocal AdeptOffload co;
-    // static G4ThreadLocal NoOffload co;
-    return co;
+    return local_offloader();
 }

--- a/GPUOffload/GPUOffload.cc
+++ b/GPUOffload/GPUOffload.cc
@@ -54,7 +54,7 @@ build_offloader(GPUOffloadOptions const& op)
             break;
     }
     // only logical return here, but we should never get here
-    return std::unique_ptr<GPUOffloadInterface>(nullptr);
+    return nullptr;
 }
 
 // Return ref to thread-local offloader backend

--- a/GPUOffload/GPUOffload.cc
+++ b/GPUOffload/GPUOffload.cc
@@ -1,12 +1,11 @@
 #include "GPUOffload.hh"
 
 #include <memory>
+#include <G4Exception.hh>
+#include <G4Threading.hh>
 
-#include "celeritas/CeleritasOffload.hh"
-
-#include "G4Exception.hh"
-#include "G4Threading.hh"
 #include "adept/AdeptOffload.hh"
+#include "celeritas/CeleritasOffload.hh"
 #include "none/NoOffload.hh"
 
 namespace

--- a/GPUOffload/GPUOffload.hh
+++ b/GPUOffload/GPUOffload.hh
@@ -2,7 +2,27 @@
 
 #include "GPUOffloadInterface.hh"
 
-// Offloader instance is thread local (for Celeritas only at present)
-// NB: Choosing between AdePT/Celeritas might be tricky because it's required
-// that the returned reference is thread-local.
-GPUOffloadInterface& GPUOffload(/* argument to choose implementation ?*/);
+//! Available offload backends
+enum class GPUOffloadBackend
+{
+  Adept,
+  Celeritas,
+  None,
+  Unknown
+};
+
+//! Options for type of offload backend and its parameters
+struct GPUOffloadOptions
+{
+  //! Implementation to use for offload backend
+  GPUOffloadBackend backend = GPUOffloadBackend::Unknown;
+
+  //! True if known backend selected
+  explicit operator bool() const { return backend != GPUOffloadBackend::Unknown; }
+};
+
+//! Setup offload backend from input options
+void GPUOffloadSetup(const GPUOffloadOptions& opts);
+
+//! Get reference to offloader for the current thread
+GPUOffloadInterface& GPUOffload();

--- a/GPUOffload/GPUOffloadInterface.hh
+++ b/GPUOffload/GPUOffloadInterface.hh
@@ -1,8 +1,7 @@
 #pragma once
 
 #include <memory>
-
-#include "G4VTrackingManager.hh"
+#include <G4VTrackingManager.hh>
 
 class G4Event;
 class G4Run;

--- a/GPUOffload/none/NoOffload.cc
+++ b/GPUOffload/none/NoOffload.cc
@@ -1,6 +1,6 @@
 #include "NoOffload.hh"
 
-#include "G4VTrackingManager.hh"
+#include <G4VTrackingManager.hh>
 
 // Return concrete tracking manager for this offloader
 std::unique_ptr<G4VTrackingManager> NoOffload::MakeTrackingManager()
@@ -9,7 +9,7 @@ std::unique_ptr<G4VTrackingManager> NoOffload::MakeTrackingManager()
 }
 
 //! Initialization of this class on a worker thread
-void NoOffload::Build(){};
+void NoOffload::Build() {};
 
 //! Initialization of this class on the master thread
 void NoOffload::BuildForMaster() {}

--- a/trackingmanager-offload.cc
+++ b/trackingmanager-offload.cc
@@ -197,7 +197,7 @@ class DetectorConstruction final : public G4VUserDetectorConstruction
   public:
     DetectorConstruction()
         : aluminum_{new G4Material{
-            "Aluminium", 13., 26.98 * g / mole, 2.700 * g / cm3}}
+              "Aluminium", 13., 26.98 * g / mole, 2.700 * g / cm3}}
     {
     }
 
@@ -272,6 +272,15 @@ class ActionInitialization final : public G4VUserActionInitialization
 
 int main()
 {
+    // This could come from CLI, JSON, or even set via UI commands (provided 
+    // PreInit Geant4 state requirement respected)
+    GPUOffloadOptions opts;
+    opts.backend = GPUOffloadBackend::Celeritas;
+
+    // can only be called in Geant4 PreInit stage (i.e. prior to RunManager
+    // initialization)
+    GPUOffloadSetup(opts);
+
     std::unique_ptr<G4RunManager> run_manager{
         G4RunManagerFactory::CreateRunManager()};
     run_manager->SetUserInitialization(new DetectorConstruction{});
@@ -293,7 +302,7 @@ int main()
     run_manager->BeamOn(10);
     // This causes an exception in Celeritas "celeritas::activate_device may be
     // called only once per application" AdePT is fine
-    //run_manager->BeamOn(16);
+    // run_manager->BeamOn(16);
 
     return 0;
 }


### PR DESCRIPTION
As outlined in Issue #5, the type of GPU offload implementation (none, adept, or celeritas) is currently hardcoded at compile time. For testing and use locally and by experiments, this should be selectable at runtime, with additional configuration options passed to the selected backend as needed.

Implement basic runtime selection of offloading backend via:

- An `enum class` representing the available backends, with an "unknown" entry to represent "unconfigured" state.
- A struct to hold the selected backend as a parameter.
- A user function that should be called at application start (strictly during Geant4's "PreInit" state) to setup the chosen backend.
- Private functions to construct required thread-local static instances of the selected backend, given the static global configuration.

A minimal demo of use is implemented in the smoke test application. Whilst still hardcoded, this is now in a location that can be configured in a variety of ways later on.