### PR TITLE
Add backend for CPU-only Celeritas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ cuda_rdc_add_library(GPUOffload
   GPUOffload/GPUOffload.cc
   GPUOffload/adept/AdeptOffload.cc
   GPUOffload/celeritas/CeleritasOffload.cc
+  GPUOffload/celeritas/CeleritasOffloadBuilder.cc
   GPUOffload/celeritas/Celeritas.cc
   GPUOffload/none/NoOffload.cc)
 cuda_rdc_target_include_directories(GPUOffload

--- a/GPUOffload/GPUOffload.cc
+++ b/GPUOffload/GPUOffload.cc
@@ -5,7 +5,7 @@
 #include <G4Threading.hh>
 
 #include "adept/AdeptOffload.hh"
-#include "celeritas/CeleritasOffload.hh"
+#include "celeritas/CeleritasOffloadBuilder.hh"
 #include "none/NoOffload.hh"
 
 namespace
@@ -45,7 +45,8 @@ build_offloader(GPUOffloadOptions const& op)
         case GPUOffloadBackend::Adept:
             return std::make_unique<AdeptOffload>();
         case GPUOffloadBackend::Celeritas:
-            return std::make_unique<CeleritasOffload>();
+        case GPUOffloadBackend::CeleritasCPU:
+            return BuildCeleritasOffload(op); 
         case GPUOffloadBackend::None:
             return std::make_unique<NoOffload>();
         default:

--- a/GPUOffload/GPUOffload.hh
+++ b/GPUOffload/GPUOffload.hh
@@ -7,6 +7,7 @@ enum class GPUOffloadBackend
 {
   Adept,
   Celeritas,
+  CeleritasCPU,
   None,
   Unknown
 };

--- a/GPUOffload/celeritas/CeleritasOffloadBuilder.cc
+++ b/GPUOffload/celeritas/CeleritasOffloadBuilder.cc
@@ -1,6 +1,7 @@
 #include "CeleritasOffloadBuilder.hh"
 
 #include <G4Exception.hh>
+#include <corecel/Assert.hh>
 #include <corecel/Macros.hh>
 #include <corecel/sys/Environment.hh>
 
@@ -31,6 +32,7 @@ BuildCeleritasOffload(GPUOffloadOptions const& opts)
         // Temporary hack. Follow https://github.com/celeritas-project/celeritas/issues/1037
         // for future solution through parameters
         celeritas::environment().insert({"CELER_DISABLE_DEVICE", "1"});
+        CELER_ENSURE(celeritas::getenv("CELER_DISABLE_DEVICE") == "1");
     }
     else
     {

--- a/GPUOffload/celeritas/CeleritasOffloadBuilder.cc
+++ b/GPUOffload/celeritas/CeleritasOffloadBuilder.cc
@@ -1,0 +1,44 @@
+#include "CeleritasOffloadBuilder.hh"
+
+#include <G4Exception.hh>
+#include <corecel/Macros.hh>
+#include <corecel/sys/Environment.hh>
+
+std::unique_ptr<CeleritasOffload>
+BuildCeleritasOffload(GPUOffloadOptions const& opts)
+{
+    if (opts.backend == GPUOffloadBackend::Celeritas)
+    {
+        if (!CELER_USE_DEVICE)
+        {
+            G4Exception("CeleritasOffloadBuilder.cc::BuildCeleritasOffload",
+                        "CeleritasOffloadBuilder0001",
+                        FatalException,
+                        "Requested Celeritas GPU offload, but Celeritas was "
+                        "not compiled with GPU support");
+        }
+        if (!celeritas::getenv("CELER_DISABLE_DEVICE").empty())
+        {
+            G4Exception("CeleritasOffloadBuilder.cc::BuildCeleritasOffload",
+                        "CeleritasOffloadBuilder0002",
+                        FatalException,
+                        "Requested Celeritas GPU offload, but "
+                        "CELER_DISABLE_DEVICE environment variable set");
+        }
+    }
+    else if (opts.backend == GPUOffloadBackend::CeleritasCPU)
+    {
+        // Temporary hack. Follow https://github.com/celeritas-project/celeritas/issues/1037
+        // for future solution through parameters
+        celeritas::environment().insert({"CELER_DISABLE_DEVICE", "1"});
+    }
+    else
+    {
+        G4Exception("CeleritasOffloadBuilder.cc::BuildCeleritasOffload",
+                    "CeleritasOffloadBuilder0003",
+                    FatalException,
+                    "GPUOffloadOptions.backend was not Celeritas or "
+                    "CeleritasCPU");
+    }
+    return std::make_unique<CeleritasOffload>();
+}

--- a/GPUOffload/celeritas/CeleritasOffloadBuilder.hh
+++ b/GPUOffload/celeritas/CeleritasOffloadBuilder.hh
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <memory>
+
+#include "GPUOffload.hh"
+
+#include "CeleritasOffload.hh"
+
+std::unique_ptr<CeleritasOffload>
+BuildCeleritasOffload(GPUOffloadOptions const& opts);


### PR DESCRIPTION
As Celeritas can run in CPU only mode, introduce an additional "backend" for running this explicitly. Whilst this can be activated by setting the CELER_DISABLE_DEVICE environment variable, adding an enum element and option makes this more explicit for end users, and will match what we will do for AdePT's CPU-only mode.

Add "CeleritasCPU" to backend enum. Factor construction of Celeritas offloader to a function, checking/validating that build/runtime requirements for using the requested GPU/CPU mode are met. 

Part of #10, AdePT CPU only mode will be next, using G4HepEM/TrackingManager.